### PR TITLE
dont clobber the additional fields when updating username/pw

### DIFF
--- a/passbox
+++ b/passbox
@@ -190,10 +190,11 @@ new_details () {
 #######################################
 write_pass () {
     local gpgpass=$password
+    local addlfields=${1:-}
     if [ -z "${userpass+x}" ] ; then
         new_entry_string=""
     else
-        new_entry_string="${passname}${SEPERATOR}${username}${SEPERATOR}${userpass}"
+        new_entry_string="${passname}${SEPERATOR}${username}${SEPERATOR}${userpass}${addlfields}"
     fi
 
     if [ -z "${gpgpass+x}" ]; then
@@ -327,16 +328,22 @@ _new () {
 #######################################
 _update () {
     local gpgpass=""
+    local addlfields=""
 
     get_pass "Enter password to unlock ${PASSBOX}: " ; echo
     gpgpass=${password}
 
     details=$(decrypt "${password}" | grep -i "^$1[${SEPERATOR}]")
     split_line "${details}"
+    for i in "${!pass_vals[@]}"; do
+        if [[ $i -gt 2 ]]; then
+            addlfields="$addlfields$SEPERATOR${pass_vals[i]}"
+        fi
+    done
     if [[ ${#pass_vals[@]} -gt 1 ]] ; then
         new_details "${pass_vals[0]}" "${pass_vals[1]}" "${pass_vals[2]}" &&
             password=$gpgpass &&
-            write_pass
+            write_pass "$addlfields"
     else
         fail "Could not find a password entry for '${1}'"
     fi

--- a/test/update-tests.bats
+++ b/test/update-tests.bats
@@ -21,6 +21,25 @@ load test_helper
     assert_line 1 "Entry 2|updatedentry@test.com|newpassword"
 }
 
+@test "update: Updates an existing entry in the passbox file that has a additional field" {
+    local new_entry_username="updatedentry@test.com"
+    local new_entry_pass="newpassword"
+    local db_password="password 123456"
+
+    ( echo "Entry 1|entry1@test.com|pass1234|Foo:Bar";
+      echo "Entry 2|entry2@test.com|1234pass|Foo:Baz" ) | encrypt "$db_password"
+
+    ( echo "$db_password";
+      echo "$new_entry_username";
+      echo "n";
+      echo "$new_entry_pass" ) | ./passbox update "Entry 2" >/dev/null
+
+    run decrypt "$db_password" "$PASSBOX_LOCATION"
+
+    assert_line 0 "Entry 1|entry1@test.com|pass1234|Foo:Bar"
+    assert_line 1 "Entry 2|updatedentry@test.com|newpassword|Foo:Baz"
+}
+
 @test "update: Displays an error if no entry name argument is specified" {
     run ./passbox update
 


### PR DESCRIPTION
The update command is dropping any additional fields that may have been added prior. 
